### PR TITLE
LIBAVALON-166. Initial implementation of adding "bibRef" note

### DIFF
--- a/scripts/avalon.py
+++ b/scripts/avalon.py
@@ -198,6 +198,18 @@ class Object:
                         text += " " + node.getAttribute('units')
                         self.physical_description += text
 
+            # relationships
+            elif e.nodeName == 'relationships':
+
+                for node in e.childNodes:
+                    if node.nodeName == 'relation':
+                        relation = node.getAttribute('label')
+                        if relation == 'archivalcollection':
+                            for relationChild in node.childNodes:
+                                if relationChild.nodeName == 'bibRef':
+                                    note_text = relationChild.toxml().encode("unicode_escape").decode("utf-8")
+                                    self.note.append(('general', note_text))
+
             # rights
             elif e.nodeName == 'rights':
                 if self.terms_of_use:


### PR DESCRIPTION
Added "bibRef" XML node from an "archivalcollection" XML relation node
as a "general" note type, with the entire XML of the bibRef
(including newlines and spaces) as part of the note.

https://issues.umd.edu/browse/LIBAVALON-166
