### PR TITLE
LIBAVALON-166. Convert bibref to multiline general note

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ exported-id-index/
 .settings
 
 pids.txt
+
+scripts/__pycache__

--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ files
 * Input: export.csv and exported objects and datastreams
 * Output: Avalon formatted batch_manifest.csv
 
+[scripts/unit_tests.py](scripts/unit_tests.py) - Unit tests for verifying
+behavior of scripts
+
 ## Building
 
 The migration-utils Java software is built with [Maven 3](https://maven.apache.org)

--- a/scripts/avalon.py
+++ b/scripts/avalon.py
@@ -5,7 +5,7 @@ import logging
 from argparse import ArgumentParser, Namespace
 from csv import DictReader, writer
 from pathlib import Path
-from typing import Optional, Iterable, Union
+from typing import Dict, Iterable, List, Optional, Union
 from xml.dom.minidom import parse, Element, Node, Text
 
 # Convert Fedora exported objects to Avalon input format.
@@ -95,7 +95,7 @@ class Object:
                 agent_type = e.getAttribute('type')
                 for node in e.childNodes:
                     if node.nodeName in ('persName', 'corpName'):
-                        text = get_text(node.childNodes)
+                        text = XmlUtils.get_text(node.childNodes)
                         if agent_type == 'contributor':
                             self.contributor.append(text)
                         elif agent_type == 'creator':
@@ -106,7 +106,7 @@ class Object:
             # covPlace
             elif e.nodeName == 'covPlace':
                 for geogName in e.getElementsByTagName('geogName'):
-                    text = get_text(geogName.childNodes)
+                    text = XmlUtils.get_text(geogName.childNodes)
                     if text != 'not captured':
                         self.geographic_subject.append(text)
 
@@ -114,7 +114,7 @@ class Object:
             elif e.nodeName == 'covTime':
 
                 for date in e.getElementsByTagName('date'):
-                    self.date_issued = get_text(date.childNodes)
+                    self.date_issued = XmlUtils.get_text(date.childNodes)
 
                 for dateRange in e.getElementsByTagName('dateRange'):
                     date_from = dateRange.getAttribute('from')
@@ -122,7 +122,7 @@ class Object:
                     self.date_issued = date_from + "/" + date_to
 
                 for century in e.getElementsByTagName('century'):
-                    text = get_text(century.childNodes)
+                    text = XmlUtils.get_text(century.childNodes)
 
                     # Save the century as date range, in case we need it for the
                     # date_issued
@@ -132,7 +132,7 @@ class Object:
             elif e.nodeName == 'description':
 
                 description_type = e.getAttribute('type')
-                text = get_text(e.childNodes)
+                text = XmlUtils.get_text(e.childNodes)
 
                 if description_type == 'summary':
                     if self.abstract:
@@ -145,7 +145,7 @@ class Object:
             # language
             elif e.nodeName == 'language':
 
-                text = get_text(e.childNodes)
+                text = XmlUtils.get_text(e.childNodes)
                 for value in text.split("; "):
                     if value in languageMap:
                         value = languageMap[value]
@@ -155,7 +155,7 @@ class Object:
             elif e.nodeName == 'subject':
 
                 subject_type = e.getAttribute('type')
-                text = get_text(e.childNodes)
+                text = XmlUtils.get_text(e.childNodes)
 
                 if subject_type == 'genre':
                     self.genre.append(text)
@@ -165,7 +165,7 @@ class Object:
 
             # culture
             elif e.nodeName == 'culture':
-                text = get_text(e.childNodes)
+                text = XmlUtils.get_text(e.childNodes)
                 if text != 'not captured':
                     self.topical_subject.append(text + ' Culture')
 
@@ -173,7 +173,7 @@ class Object:
             elif e.nodeName == 'identifier':
 
                 identifier_type = e.getAttribute('type')
-                text = get_text(e.childNodes)
+                text = XmlUtils.get_text(e.childNodes)
 
                 if identifier_type == 'oclc':
                     self.other_identifier.append(('oclc', text))
@@ -185,7 +185,7 @@ class Object:
             elif e.nodeName == 'physDesc':
 
                 for node in e.childNodes:
-                    text = get_text(node.childNodes)
+                    text = XmlUtils.get_text(node.childNodes)
 
                     if node.nodeName in ('color', 'format'):
                         if self.physical_description:
@@ -207,7 +207,7 @@ class Object:
                         if relation == 'archivalcollection':
                             for relationChild in node.childNodes:
                                 if relationChild.nodeName == 'bibRef':
-                                    note_text = bibref_to_note_text(relationChild)
+                                    note_text = BibRefToTextConverter.as_text(relationChild)
                                     escaped_note_text = note_text.encode("unicode_escape").decode("utf-8")
                                     self.note.append(('general', escaped_note_text))
 
@@ -215,11 +215,115 @@ class Object:
             elif e.nodeName == 'rights':
                 if self.terms_of_use:
                     self.terms_of_use += '; '
-                self.terms_of_use += get_text(e.childNodes)
+                self.terms_of_use += XmlUtils.get_text(e.childNodes)
 
         # Use century for date_issued, if necessary
         if not self.date_issued and century_date_range:
             self.date_issued = century_date_range
+
+
+class XmlUtils:
+    '''Utilties for handling minidom XML elements'''
+    @staticmethod
+    def collapse_whitespace_nodes(element: Element):
+        '''Collapses extraneous whitespace child elements in given element,
+        and normalizes. This method preserves the XML tag information.
+        Largely taken from "remove_whitespace" method in
+        https://realpython.com/python-xml-parser/'''
+        if element.nodeType == Node.TEXT_NODE:
+            if element.nodeValue.strip() == "":
+                element.nodeValue = ""
+        for child in element.childNodes:
+            XmlUtils.collapse_whitespace_nodes(child)
+        element.normalize()
+
+    @staticmethod
+    def get_text(nodelist: Iterable[Union[Element, Text]]) -> str:
+        '''Extract text from an XML node list'''
+        return ''.join(node.data.strip().replace('\n', '') for node in nodelist if node.nodeType == node.TEXT_NODE)
+
+
+class BibRefToTextConverter:
+    '''Converts <bibRef> XML element into a text string'''
+    @staticmethod
+    def as_text(bib_ref: Element) -> str:
+        '''Converts <bibRef> nodes into multi-line text describing the bibRef'''
+        XmlUtils.collapse_whitespace_nodes(bib_ref)
+
+        bib_ref_dict = BibRefToTextConverter.bib_ref_to_dict(bib_ref)
+        text_elements = BibRefToTextConverter.bib_ref_dict_to_text(bib_ref_dict)
+
+        result_text = ', '.join(text_elements)
+        return result_text
+
+    @staticmethod
+    def bib_ref_to_dict(bib_ref: Element) -> Dict[str, List[str]]:
+        '''
+        Converts a bibRef into a Dict with keys based on tag name or
+        bibScope type.
+
+        The key for each entry is either:
+          * the tag name (such as "title"),
+          * for "<bibScope>" tags only, the "type" attribute
+
+        The value stored in the map is a list (as there could possibly be
+        multiple instance of a tag or bibScope type) -- there will be one entry
+        in the list for each instance.
+        '''
+        bib_ref_items: Dict[str, List[str]] = {}
+        for e in bib_ref.childNodes:
+            item_text = XmlUtils.get_text(e.childNodes).strip()
+            if item_text == '':
+                continue
+
+            node_name = e.nodeName
+            key = node_name
+            if (node_name == 'bibScope'):
+                key = e.getAttribute('type')
+
+            entries = bib_ref_items.get(key, [])
+            entries.append(item_text)
+            bib_ref_items[key] = entries
+
+        return bib_ref_items
+
+    @staticmethod
+    def bib_ref_dict_to_text(bib_ref_dict: Dict[str, List[str]]) -> List[str]:
+        '''
+        Converted the bibRef dict into a text string, ensuring that the
+        text from the <title> tag (if present) appears first, followed by
+        the bibScope types in a defined order (skipping any missing types).
+
+        Any other tags or bibScope types are placed at the end, in an undefined
+        order.
+        '''
+        bibscope_output_order = ['accession', 'series', 'subseries', 'box', 'folder', 'item']
+        text_elements = []
+
+        # Title is always first
+        if 'title' in bib_ref_dict:
+            title_entries = bib_ref_dict['title']
+            for title in title_entries:
+                text_elements.append(title)
+
+            del bib_ref_dict['title']
+
+        # Bibscopes in provided order
+        for bibscope_type in bibscope_output_order:
+            if bibscope_type in bib_ref_dict:
+                caption = bibscope_type.capitalize()
+                for entry in bib_ref_dict[bibscope_type]:
+                    text_elements.append(f"{caption} {entry}")
+
+                del bib_ref_dict[bibscope_type]
+
+        # Anything left in the bib_ref_items goes at the end
+        for key, value in bib_ref_dict.items():
+            caption = key.capitalize()
+            for entry in value:
+                text_elements.append(f"{caption} {entry}")
+
+        return text_elements
 
 
 def process_args() -> Namespace:
@@ -381,48 +485,6 @@ def write_csv(title: str, email: str, manifest_path: Path, objects: Iterable) ->
 
             # Write the row
             manifest_csv.writerow(row)
-
-
-def collapse_whitespace_nodes(element: Element):
-    '''Collapses extraneous whitespace child elements in given element,
-       and normalizes.
-       Largely taken from "remove_whitespace" method in
-       https://realpython.com/python-xml-parser/'''
-    if element.nodeType == Node.TEXT_NODE:
-        if element.nodeValue.strip() == "":
-            element.nodeValue = ""
-    for child in element.childNodes:
-        collapse_whitespace_nodes(child)
-    element.normalize()
-
-
-def bibref_to_note_text(bibref: Element) -> str:
-    '''Converts <bibref> child nodes into multi-line text describing the bibref'''
-    collapse_whitespace_nodes(bibref)
-    bibref_items = []
-    for e in bibref.childNodes:
-        item_text = get_text(e.childNodes).strip()
-        if item_text == '':
-            continue
-
-        caption = ''
-        if e.nodeName == 'bibScope':
-            caption = e.getAttribute('type') + ' '
-
-        bibref_item = f"{caption.capitalize()}{item_text}".strip()
-
-        # Ensure <title>, if present, is first in bibref_items
-        if e.nodeName == 'title':
-            bibref_items.insert(0, bibref_item)
-        else:
-            bibref_items.append(bibref_item)
-    item_separator = ', '
-    return item_separator.join(bibref_items)
-
-
-def get_text(nodelist: Iterable[Union[Element, Text]]) -> str:
-    """Extract text from an XML node list."""
-    return ''.join(node.data.strip().replace('\n', '') for node in nodelist if node.nodeType == node.TEXT_NODE)
 
 
 def multicolumn(values: list, size: int, max_count: int) -> list:

--- a/scripts/unit_tests.py
+++ b/scripts/unit_tests.py
@@ -4,74 +4,93 @@
 import unittest
 
 from xml.dom.minidom import parseString
-from avalon import bibref_to_note_text, collapse_whitespace_nodes
+from avalon import BibRefToTextConverter, XmlUtils
 
 
-class TestBibRefToNoteText(unittest.TestCase):
-    '''Test cases for the 'bibref_to_note_text' method in avalon.py'''
+class TestBibRefToTextConverter(unittest.TestCase):
+    '''Test cases for the 'bib_ref_to_note_text' method in avalon.py'''
 
     @staticmethod
     def to_element(xml: str):
         '''Converts the given string into minidom Element'''
         doc = parseString(str(xml))
-        collapse_whitespace_nodes(doc)
+        XmlUtils.collapse_whitespace_nodes(doc)
         doc_element = doc.documentElement
         return doc_element
 
-    def test_bibref_with_no_children(self):
+    def test_bib_ref_with_no_children(self):
         xml = '<bibRef />'
-        bibref = self.to_element(xml)
-        self.assertEqual('', bibref_to_note_text(bibref))
+        bib_ref = self.to_element(xml)
+        self.assertEqual('', BibRefToTextConverter.as_text(bib_ref))
 
         xml = '<bibRef></bibRef>'
-        bibref = self.to_element(xml)
-        self.assertEqual('', bibref_to_note_text(bibref))
+        bib_ref = self.to_element(xml)
+        self.assertEqual('', BibRefToTextConverter.as_text(bib_ref))
 
-    def test_bibref_with_only_title(self):
+    def test_bib_ref_with_only_title(self):
         xml = '<bibRef>\n        <title type="main">Madrigal Singers</title>\n      </bibRef>'
-        bibref = self.to_element(xml)
-        self.assertEqual('Madrigal Singers', bibref_to_note_text(bibref))
+        bib_ref = self.to_element(xml)
+        self.assertEqual('Madrigal Singers', BibRefToTextConverter.as_text(bib_ref))
 
-    def test_bibref_with_title_and_accession(self):
+    def test_bib_ref_with_title_and_accession(self):
         xml = '<bibRef><title type="main">University of Maryland\xa0Football\xa0Heritage\xa0Film\xa0Collection</title>\n<bibScope type="accession">2011-166</bibScope></bibRef>'
-        bibref = self.to_element(xml)
-        self.assertEqual('University of Maryland\xa0Football\xa0Heritage\xa0Film\xa0Collection, Accession 2011-166', bibref_to_note_text(bibref))
+        bib_ref = self.to_element(xml)
+        self.assertEqual('University of Maryland\xa0Football\xa0Heritage\xa0Film\xa0Collection, Accession 2011-166', BibRefToTextConverter.as_text(bib_ref))
 
-    def test_bibref_with_title_and_box_and_accession(self):
+    def test_bib_ref_with_title_and_box_and_accession(self):
         xml = '<bibRef>\n        <title type="main">WMUC Archives</title>\n        <bibScope type="box">1</bibScope>\n        <bibScope type="accession">2011-084</bibScope>\n      </bibRef>'
-        bibref = self.to_element(xml)
-        self.assertEqual('WMUC Archives, Box 1, Accession 2011-084', bibref_to_note_text(bibref))
+        bib_ref = self.to_element(xml)
+        self.assertEqual('WMUC Archives, Accession 2011-084, Box 1', BibRefToTextConverter.as_text(bib_ref))
 
-    def test_bibref_with_empty_title_and_empty_box_and_accession(self):
+    def test_bib_ref_with_empty_title_and_empty_box_and_accession(self):
         xml = '<bibRef>\n                <title type="main"/>\n                <bibScope type="box"/>\n                <bibScope type="accession">2011-084</bibScope>\n              </bibRef>'
-        bibref = self.to_element(xml)
-        self.assertEqual('Accession 2011-084', bibref_to_note_text(bibref))
+        bib_ref = self.to_element(xml)
+        self.assertEqual('Accession 2011-084', BibRefToTextConverter.as_text(bib_ref))
 
-    def test_bibref_with_title_and_series_and_box_and_folder_and_item(self):
+    def test_bib_ref_with_title_and_series_and_box_and_folder_and_item(self):
         xml = '<bibRef>\n        <title type="main">Jackson R. Bryer Interviews Collection</title>\n        <bibScope type="series">1</bibScope>\n        <bibScope type="box">1</bibScope>\n        <bibScope type="folder">1</bibScope>\n        <bibScope type="item">5.0</bibScope>\n      </bibRef>'
-        bibref = self.to_element(xml)
-        self.assertEqual('Jackson R. Bryer Interviews Collection, Series 1, Box 1, Folder 1, Item 5.0', bibref_to_note_text(bibref))
+        bib_ref = self.to_element(xml)
+        self.assertEqual('Jackson R. Bryer Interviews Collection, Series 1, Box 1, Folder 1, Item 5.0', BibRefToTextConverter.as_text(bib_ref))
 
-    def test_bibref_with_no_title_and_accession(self):
+    def test_bib_ref_with_no_title_and_accession(self):
         xml = '<bibRef>\n                \n                \n                <bibScope type="accession">2011-084</bibScope>\n              </bibRef>'
-        bibref = self.to_element(xml)
-        self.assertEqual('Accession 2011-084', bibref_to_note_text(bibref))
+        bib_ref = self.to_element(xml)
+        self.assertEqual('Accession 2011-084', BibRefToTextConverter.as_text(bib_ref))
 
-    def test_bibref_with_empty_title(self):
+    def test_bib_ref_with_empty_title(self):
         xml = '<bibRef><title type="main"/></bibRef>'
-        bibref = self.to_element(xml)
-        self.assertEqual('', bibref_to_note_text(bibref))
+        bib_ref = self.to_element(xml)
+        self.assertEqual('', BibRefToTextConverter.as_text(bib_ref))
 
     def test_bib_with_title_and_series_and_accession_and_subseries_and_item(self):
         xml = '<bibRef><title type="main">United Brotherhood of Carpenters and Joiners America (UBC) archives</title>\n<bibScope type="series">16</bibScope>\n<bibScope type="accession">1995-94</bibScope>\n<bibScope type="subseries">2</bibScope>\n<bibScope type="item">Audio #32</bibScope></bibRef>'
-        bibref = self.to_element(xml)
-        self.assertEqual('United Brotherhood of Carpenters and Joiners America (UBC) archives, Series 16, Accession 1995-94, Subseries 2, Item Audio #32', bibref_to_note_text(bibref))
+        bib_ref = self.to_element(xml)
+        self.assertEqual('United Brotherhood of Carpenters and Joiners America (UBC) archives, Accession 1995-94, Series 16, Subseries 2, Item Audio #32', BibRefToTextConverter.as_text(bib_ref))
 
-    def test_bibref_with_title_and_accession_displays_title_first(self):
+    def test_bib_ref_with_title_and_accession_displays_title_first(self):
         xml = '<bibRef><bibScope type="accession">2011-166</bibScope>\n<title type="main">Test Title</title></bibRef>'
-        bibref = self.to_element(xml)
-        self.assertEqual('Test Title, Accession 2011-166', bibref_to_note_text(bibref))
+        bib_ref = self.to_element(xml)
+        self.assertEqual('Test Title, Accession 2011-166', BibRefToTextConverter.as_text(bib_ref))
 
+    def test_bib_ref_with_unexpected_bibscope_puts_bibscope_at_end(self):
+        xml = '<bibRef><title type="main">Test Title</title>\n<bibScope type="accession">2011-166</bibScope><bibScope type="unknownScope">abc123</bibScope>\n</bibRef>'
+        bib_ref = self.to_element(xml)
+        self.assertEqual('Test Title, Accession 2011-166, Unknownscope abc123', BibRefToTextConverter.as_text(bib_ref))
+
+    def test_bib_ref_with_unexpected_xml_puts_xml_at_end(self):
+        xml = '<bibRef><title type="main">Test Title</title>\n<subtitle>Test Subtitle</subtitle>\n<bibScope type="accession">2011-166</bibScope><bibScope type="unknownScope">abc123</bibScope>\n</bibRef>'
+        bib_ref = self.to_element(xml)
+        self.assertEqual('Test Title, Accession 2011-166, Subtitle Test Subtitle, Unknownscope abc123', BibRefToTextConverter.as_text(bib_ref))
+
+    def test_bib_ref_with_multiple_titles_displays_multiple_titles(self):
+        xml = '<bibRef><title type="main">Test Title 1</title>\n<title type="main">Test Title 2</title>\n<bibScope type="accession">2011-166</bibScope>\n</bibRef>'
+        bib_ref = self.to_element(xml)
+        self.assertEqual('Test Title 1, Test Title 2, Accession 2011-166', BibRefToTextConverter.as_text(bib_ref))
+
+    def test_bib_ref_with_multiple_bibscopes_displays_multiple_entries(self):
+        xml = '<bibRef><title type="main">Test Title</title>\n<bibScope type="accession">2011-166</bibScope><bibScope type="accession">ABC-123</bibScope></bibRef>'
+        bib_ref = self.to_element(xml)
+        self.assertEqual('Test Title, Accession 2011-166, Accession ABC-123', BibRefToTextConverter.as_text(bib_ref))
 
 if __name__ == '__main__':
     unittest.main()

--- a/scripts/unit_tests.py
+++ b/scripts/unit_tests.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+
+'''Unit tests for Python scripts'''
+import unittest
+
+from xml.dom.minidom import parseString
+from avalon import bibref_to_note_text, collapse_whitespace_nodes
+
+
+class TestBibRefToNoteText(unittest.TestCase):
+    '''Test cases for the 'bibref_to_note_text' method in avalon.py'''
+
+    @staticmethod
+    def to_element(xml: str):
+        '''Converts the given string into minidom Element'''
+        doc = parseString(str(xml))
+        collapse_whitespace_nodes(doc)
+        doc_element = doc.documentElement
+        return doc_element
+
+    def test_bibref_with_no_children(self):
+        xml = '<bibRef />'
+        bibref = self.to_element(xml)
+        self.assertEqual('', bibref_to_note_text(bibref))
+
+        xml = '<bibRef></bibRef>'
+        bibref = self.to_element(xml)
+        self.assertEqual('', bibref_to_note_text(bibref))
+
+    def test_bibref_with_only_title(self):
+        xml = '<bibRef>\n        <title type="main">Madrigal Singers</title>\n      </bibRef>'
+        bibref = self.to_element(xml)
+        self.assertEqual('Madrigal Singers', bibref_to_note_text(bibref))
+
+    def test_bibref_with_title_and_accession(self):
+        xml = '<bibRef><title type="main">University of Maryland\xa0Football\xa0Heritage\xa0Film\xa0Collection</title>\n<bibScope type="accession">2011-166</bibScope></bibRef>'
+        bibref = self.to_element(xml)
+        self.assertEqual('University of Maryland\xa0Football\xa0Heritage\xa0Film\xa0Collection, Accession 2011-166', bibref_to_note_text(bibref))
+
+    def test_bibref_with_title_and_box_and_accession(self):
+        xml = '<bibRef>\n        <title type="main">WMUC Archives</title>\n        <bibScope type="box">1</bibScope>\n        <bibScope type="accession">2011-084</bibScope>\n      </bibRef>'
+        bibref = self.to_element(xml)
+        self.assertEqual('WMUC Archives, Box 1, Accession 2011-084', bibref_to_note_text(bibref))
+
+    def test_bibref_with_empty_title_and_empty_box_and_accession(self):
+        xml = '<bibRef>\n                <title type="main"/>\n                <bibScope type="box"/>\n                <bibScope type="accession">2011-084</bibScope>\n              </bibRef>'
+        bibref = self.to_element(xml)
+        self.assertEqual('Accession 2011-084', bibref_to_note_text(bibref))
+
+    def test_bibref_with_title_and_series_and_box_and_folder_and_item(self):
+        xml = '<bibRef>\n        <title type="main">Jackson R. Bryer Interviews Collection</title>\n        <bibScope type="series">1</bibScope>\n        <bibScope type="box">1</bibScope>\n        <bibScope type="folder">1</bibScope>\n        <bibScope type="item">5.0</bibScope>\n      </bibRef>'
+        bibref = self.to_element(xml)
+        self.assertEqual('Jackson R. Bryer Interviews Collection, Series 1, Box 1, Folder 1, Item 5.0', bibref_to_note_text(bibref))
+
+    def test_bibref_with_no_title_and_accession(self):
+        xml = '<bibRef>\n                \n                \n                <bibScope type="accession">2011-084</bibScope>\n              </bibRef>'
+        bibref = self.to_element(xml)
+        self.assertEqual('Accession 2011-084', bibref_to_note_text(bibref))
+
+    def test_bibref_with_empty_title(self):
+        xml = '<bibRef><title type="main"/></bibRef>'
+        bibref = self.to_element(xml)
+        self.assertEqual('', bibref_to_note_text(bibref))
+
+    def test_bib_with_title_and_series_and_accession_and_subseries_and_item(self):
+        xml = '<bibRef><title type="main">United Brotherhood of Carpenters and Joiners America (UBC) archives</title>\n<bibScope type="series">16</bibScope>\n<bibScope type="accession">1995-94</bibScope>\n<bibScope type="subseries">2</bibScope>\n<bibScope type="item">Audio #32</bibScope></bibRef>'
+        bibref = self.to_element(xml)
+        self.assertEqual('United Brotherhood of Carpenters and Joiners America (UBC) archives, Series 16, Accession 1995-94, Subseries 2, Item Audio #32', bibref_to_note_text(bibref))
+
+    def test_bibref_with_title_and_accession_displays_title_first(self):
+        xml = '<bibRef><bibScope type="accession">2011-166</bibScope>\n<title type="main">Test Title</title></bibRef>'
+        bibref = self.to_element(xml)
+        self.assertEqual('Test Title, Accession 2011-166', bibref_to_note_text(bibref))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Modified archival collection "bibref" tags into a multiline general
note. This code assumes that the bibref consists of a "title" tag
and one or more "<bibscope>" tags, where the "<bibscope>" tags have
a "type" attribute that should be displayed as a caption.

Added "ordering" constraints to the output, such that the "Title" would
appear first, followed by bibScope types in the following order:

```
accession, series, subseries, box, folder, item
```

Any additional information from the bibRef (from either additional tags
or bibScope types) will appear at the end , in an indeterminate order.

Refactored the bibref conversion code into a "BibRefToTextConverter"
class, as the code was getting fairly complicated, and wanted to clarify
the code by organizing it into its own class.

As part of the refactoring, moved the "collapse_whitespace_nodes" and
"get_text" utility methods into an "XmlUtils" class. This way, the
"BibRefToTextConverter" class is dependent on another class, not the
functions in the script.

Added a script providing simple unit tests.

https://issues.umd.edu/browse/LIBAVALON-166