### PR TITLE
LIBAVALON-172. Replaced "Handle" field with "Other Identifier"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ exported-id-index/
 .settings
 
 pids.txt
+
+scripts/__pycache__

--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ files
 * Input: export.csv and exported objects and datastreams
 * Output: Avalon formatted batch_manifest.csv
 
+[scripts/unit_tests.py](scripts/unit_tests.py) - Unit tests for verifying
+behavior of scripts
+
 ## Building
 
 The migration-utils Java software is built with [Maven 3](https://maven.apache.org)

--- a/scripts/avalon.py
+++ b/scripts/avalon.py
@@ -77,7 +77,6 @@ class Object:
         # not currently supported
         self.file = []  # (file, label)
 
-
     def process_umdm(self, umdm_path: Path) -> None:
         """ Gather data from the UMDM xml. """
 
@@ -265,10 +264,14 @@ class XmlUtils:
     '''Utilties for handling minidom XML elements'''
     @staticmethod
     def collapse_whitespace_nodes(element: Element) -> None:
-        '''Collapses extraneous whitespace child elements in given element,
+        '''
+        Collapses extraneous whitespace child elements in given element,
         and normalizes. This method preserves the XML tag information.
         Largely taken from "remove_whitespace" method in
-        https://realpython.com/python-xml-parser/'''
+        https://realpython.com/python-xml-parser/
+
+        :param element: the Element to modify (element is modified in place)
+        '''
         if element.nodeType == Node.TEXT_NODE:
             if element.nodeValue.strip() == "":
                 element.nodeValue = ""
@@ -278,15 +281,26 @@ class XmlUtils:
 
     @staticmethod
     def get_text(nodelist: Iterable[Union[Element, Text]]) -> str:
-        '''Extract text from an XML node list'''
+        '''
+        Extract text from an XML node list
+
+        :param nodelist: an Iterable of Elements to extract the text from
+        '''
         return ''.join(node.data.strip().replace('\n', '') for node in nodelist if node.nodeType == node.TEXT_NODE)
 
 
 class BibRefToTextConverter:
-    '''Converts <bibRef> XML element into a text string'''
+    '''
+    Converts <bibRef> XML element into a text string.
+    '''
     @staticmethod
     def as_text(bib_ref: Element) -> str:
-        '''Converts <bibRef> nodes into multi-line text describing the bibRef'''
+        '''
+        Converts <bibRef> nodes into multi-line text describing the bibRef
+
+        :param bib_ref: the Element to convert
+        :return: a text string containing the information in the bibRef element
+        '''
         XmlUtils.collapse_whitespace_nodes(bib_ref)
 
         bib_ref_dict = BibRefToTextConverter.bib_ref_to_dict(bib_ref)
@@ -308,6 +322,10 @@ class BibRefToTextConverter:
         The value stored in the map is a list (as there could possibly be
         multiple instance of a tag or bibScope type) -- there will be one entry
         in the list for each instance.
+
+        :param bib_ref: the Element to convert
+        :return: A Dict of keys and values representing the information in the
+                bibRef
         '''
         bib_ref_items: Dict[str, List[str]] = {}
         for e in bib_ref.childNodes:
@@ -335,6 +353,9 @@ class BibRefToTextConverter:
 
         Any other tags or bibScope types are placed at the end, in an undefined
         order.
+
+        :param bib_ref_dict: Dict from 'bib_ref_to_dict' method to convert
+        :return: a List of Strings representing the bibRef information
         '''
         bibscope_output_order = ['accession', 'series', 'subseries', 'box', 'folder', 'item']
         text_elements = []

--- a/scripts/avalon.py
+++ b/scripts/avalon.py
@@ -5,7 +5,7 @@ import logging
 from argparse import ArgumentParser, Namespace
 from csv import DictReader, writer
 from pathlib import Path
-from typing import Optional, Iterable, Union
+from typing import Dict, Iterable, List, Optional, Union
 from xml.dom.minidom import parse, Element, Node, Text
 
 # Convert Fedora exported objects to Avalon input format.
@@ -95,7 +95,7 @@ class Object:
                 agent_type = e.getAttribute('type')
                 for node in e.childNodes:
                     if node.nodeName in ('persName', 'corpName'):
-                        text = get_text(node.childNodes)
+                        text = XmlUtils.get_text(node.childNodes)
                         if agent_type == 'contributor':
                             self.contributor.append(text)
                         elif agent_type == 'creator':
@@ -106,7 +106,7 @@ class Object:
             # covPlace
             elif e.nodeName == 'covPlace':
                 for geogName in e.getElementsByTagName('geogName'):
-                    text = get_text(geogName.childNodes)
+                    text = XmlUtils.get_text(geogName.childNodes)
                     if text != 'not captured':
                         self.geographic_subject.append(text)
 
@@ -114,7 +114,7 @@ class Object:
             elif e.nodeName == 'covTime':
 
                 for date in e.getElementsByTagName('date'):
-                    self.date_issued = get_text(date.childNodes)
+                    self.date_issued = XmlUtils.get_text(date.childNodes)
 
                 for dateRange in e.getElementsByTagName('dateRange'):
                     date_from = dateRange.getAttribute('from')
@@ -122,7 +122,7 @@ class Object:
                     self.date_issued = date_from + "/" + date_to
 
                 for century in e.getElementsByTagName('century'):
-                    text = get_text(century.childNodes)
+                    text = XmlUtils.get_text(century.childNodes)
 
                     # Save the century as date range, in case we need it for the
                     # date_issued
@@ -132,7 +132,7 @@ class Object:
             elif e.nodeName == 'description':
 
                 description_type = e.getAttribute('type')
-                text = get_text(e.childNodes)
+                text = XmlUtils.get_text(e.childNodes)
 
                 if description_type == 'summary':
                     if self.abstract:
@@ -145,7 +145,7 @@ class Object:
             # language
             elif e.nodeName == 'language':
 
-                text = get_text(e.childNodes)
+                text = XmlUtils.get_text(e.childNodes)
                 for value in text.split("; "):
                     if value in languageMap:
                         value = languageMap[value]
@@ -155,7 +155,7 @@ class Object:
             elif e.nodeName == 'subject':
 
                 subject_type = e.getAttribute('type')
-                text = get_text(e.childNodes)
+                text = XmlUtils.get_text(e.childNodes)
 
                 if subject_type == 'genre':
                     self.genre.append(text)
@@ -165,7 +165,7 @@ class Object:
 
             # culture
             elif e.nodeName == 'culture':
-                text = get_text(e.childNodes)
+                text = XmlUtils.get_text(e.childNodes)
                 if text != 'not captured':
                     self.topical_subject.append(text + ' Culture')
 
@@ -173,7 +173,7 @@ class Object:
             elif e.nodeName == 'identifier':
 
                 identifier_type = e.getAttribute('type')
-                text = get_text(e.childNodes)
+                text = XmlUtils.get_text(e.childNodes)
 
                 if identifier_type == 'oclc':
                     self.other_identifier.append(('oclc', text))
@@ -185,7 +185,7 @@ class Object:
             elif e.nodeName == 'physDesc':
 
                 for node in e.childNodes:
-                    text = get_text(node.childNodes)
+                    text = XmlUtils.get_text(node.childNodes)
 
                     if node.nodeName in ('color', 'format'):
                         if self.physical_description:
@@ -207,7 +207,7 @@ class Object:
                         if relation == 'archivalcollection':
                             for relationChild in node.childNodes:
                                 if relationChild.nodeName == 'bibRef':
-                                    note_text = bibref_to_note_text(relationChild)
+                                    note_text = BibRefToTextConverter.as_text(relationChild)
                                     escaped_note_text = note_text.encode("unicode_escape").decode("utf-8")
                                     self.note.append(('general', escaped_note_text))
 
@@ -215,11 +215,115 @@ class Object:
             elif e.nodeName == 'rights':
                 if self.terms_of_use:
                     self.terms_of_use += '; '
-                self.terms_of_use += get_text(e.childNodes)
+                self.terms_of_use += XmlUtils.get_text(e.childNodes)
 
         # Use century for date_issued, if necessary
         if not self.date_issued and century_date_range:
             self.date_issued = century_date_range
+
+
+class XmlUtils:
+    '''Utilties for handling minidom XML elements'''
+    @staticmethod
+    def collapse_whitespace_nodes(element: Element):
+        '''Collapses extraneous whitespace child elements in given element,
+        and normalizes. This method preserves the XML tag information.
+        Largely taken from "remove_whitespace" method in
+        https://realpython.com/python-xml-parser/'''
+        if element.nodeType == Node.TEXT_NODE:
+            if element.nodeValue.strip() == "":
+                element.nodeValue = ""
+        for child in element.childNodes:
+            XmlUtils.collapse_whitespace_nodes(child)
+        element.normalize()
+
+    @staticmethod
+    def get_text(nodelist: Iterable[Union[Element, Text]]) -> str:
+        '''Extract text from an XML node list'''
+        return ''.join(node.data.strip().replace('\n', '') for node in nodelist if node.nodeType == node.TEXT_NODE)
+
+
+class BibRefToTextConverter:
+    '''Converts <bibRef> XML element into a text string'''
+    @staticmethod
+    def as_text(bib_ref: Element) -> str:
+        '''Converts <bibRef> nodes into multi-line text describing the bibRef'''
+        XmlUtils.collapse_whitespace_nodes(bib_ref)
+
+        bib_ref_dict = BibRefToTextConverter.bib_ref_to_dict(bib_ref)
+        text_elements = BibRefToTextConverter.bib_ref_dict_to_text(bib_ref_dict)
+
+        result_text = ', '.join(text_elements)
+        return result_text
+
+    @staticmethod
+    def bib_ref_to_dict(bib_ref: Element) -> Dict[str, List[str]]:
+        '''
+        Converts a bibRef into a Dict with keys based on tag name or
+        bibScope type.
+
+        The key for each entry is either:
+          * the tag name (such as "title"),
+          * for "<bibScope>" tags only, the "type" attribute
+
+        The value stored in the map is a list (as there could possibly be
+        multiple instance of a tag or bibScope type) -- there will be one entry
+        in the list for each instance.
+        '''
+        bib_ref_items: Dict[str, List[str]] = {}
+        for e in bib_ref.childNodes:
+            item_text = XmlUtils.get_text(e.childNodes).strip()
+            if item_text == '':
+                continue
+
+            node_name = e.nodeName
+            key = node_name
+            if (node_name == 'bibScope'):
+                key = e.getAttribute('type')
+
+            entries = bib_ref_items.get(key, [])
+            entries.append(item_text)
+            bib_ref_items[key] = entries
+
+        return bib_ref_items
+
+    @staticmethod
+    def bib_ref_dict_to_text(bib_ref_dict: Dict[str, List[str]]) -> List[str]:
+        '''
+        Converted the bibRef dict into a text string, ensuring that the
+        text from the <title> tag (if present) appears first, followed by
+        the bibScope types in a defined order (skipping any missing types).
+
+        Any other tags or bibScope types are placed at the end, in an undefined
+        order.
+        '''
+        bibscope_output_order = ['accession', 'series', 'subseries', 'box', 'folder', 'item']
+        text_elements = []
+
+        # Title is always first
+        if 'title' in bib_ref_dict:
+            title_entries = bib_ref_dict['title']
+            for title in title_entries:
+                text_elements.append(title)
+
+            del bib_ref_dict['title']
+
+        # Bibscopes in provided order
+        for bibscope_type in bibscope_output_order:
+            if bibscope_type in bib_ref_dict:
+                caption = bibscope_type.capitalize()
+                for entry in bib_ref_dict[bibscope_type]:
+                    text_elements.append(f"{caption} {entry}")
+
+                del bib_ref_dict[bibscope_type]
+
+        # Anything left in the bib_ref_items goes at the end
+        for key, value in bib_ref_dict.items():
+            caption = key.capitalize()
+            for entry in value:
+                text_elements.append(f"{caption} {entry}")
+
+        return text_elements
 
 
 def process_args() -> Namespace:
@@ -381,48 +485,6 @@ def write_csv(title: str, email: str, manifest_path: Path, objects: Iterable) ->
 
             # Write the row
             manifest_csv.writerow(row)
-
-
-def collapse_whitespace_nodes(element: Element):
-    '''Collapses extraneous whitespace child elements in given element,
-       and normalizes.
-       Largely taken from "remove_whitespace" method in
-       https://realpython.com/python-xml-parser/'''
-    if element.nodeType == Node.TEXT_NODE:
-        if element.nodeValue.strip() == "":
-            element.nodeValue = ""
-    for child in element.childNodes:
-        collapse_whitespace_nodes(child)
-    element.normalize()
-
-
-def bibref_to_note_text(bibref: Element) -> str:
-    '''Converts <bibref> child nodes into multi-line text describing the bibref'''
-    collapse_whitespace_nodes(bibref)
-    bibref_items = []
-    for e in bibref.childNodes:
-        item_text = get_text(e.childNodes).strip()
-        if item_text == '':
-            continue
-
-        caption = ''
-        if e.nodeName == 'bibScope':
-            caption = e.getAttribute('type') + ' '
-
-        bibref_item = f"{caption.capitalize()}{item_text}".strip()
-
-        # Ensure <title>, if present, is first in bibref_items
-        if e.nodeName == 'title':
-            bibref_items.insert(0, bibref_item)
-        else:
-            bibref_items.append(bibref_item)
-    item_separator = ', '
-    return item_separator.join(bibref_items)
-
-
-def get_text(nodelist: Iterable[Union[Element, Text]]) -> str:
-    """Extract text from an XML node list."""
-    return ''.join(node.data.strip().replace('\n', '') for node in nodelist if node.nodeType == node.TEXT_NODE)
 
 
 def multicolumn(values: list, size: int, max_count: int) -> list:

--- a/scripts/avalon.py
+++ b/scripts/avalon.py
@@ -293,6 +293,12 @@ class BibRefToTextConverter:
     '''
     Converts <bibRef> XML element into a text string.
     '''
+
+    # Order to output bibScope types
+    BIBSCOPE_TYPE_OUTPUT_ORDER = [
+        'accession', 'series', 'subseries', 'box', 'folder', 'item'
+    ]
+
     @staticmethod
     def as_text(bib_ref: Element) -> str:
         '''
@@ -349,7 +355,8 @@ class BibRefToTextConverter:
         '''
         Converted the bibRef dict into a text string, ensuring that the
         text from the <title> tag (if present) appears first, followed by
-        the bibScope types in a defined order (skipping any missing types).
+        the bibScope types in the order defined by BIBSCOPE_TYPE_OUTPUT_ORDER
+        (skipping any missing types).
 
         Any other tags or bibScope types are placed at the end, in an undefined
         order.
@@ -357,28 +364,30 @@ class BibRefToTextConverter:
         :param bib_ref_dict: Dict from 'bib_ref_to_dict' method to convert
         :return: a List of Strings representing the bibRef information
         '''
-        bibscope_output_order = ['accession', 'series', 'subseries', 'box', 'folder', 'item']
         text_elements = []
 
-        # Title is always first
+        bib_ref_dict_keys = list(bib_ref_dict)
+
+        # Title is always first - no caption is added
         if 'title' in bib_ref_dict:
             title_entries = bib_ref_dict['title']
             for title in title_entries:
                 text_elements.append(title)
 
-            del bib_ref_dict['title']
+            bib_ref_dict_keys.remove('title')
 
         # Bibscopes in provided order
-        for bibscope_type in bibscope_output_order:
+        for bibscope_type in BibRefToTextConverter.BIBSCOPE_TYPE_OUTPUT_ORDER:
             if bibscope_type in bib_ref_dict:
                 caption = bibscope_type.capitalize()
                 for entry in bib_ref_dict[bibscope_type]:
                     text_elements.append(f"{caption} {entry}")
 
-                del bib_ref_dict[bibscope_type]
+                bib_ref_dict_keys.remove(bibscope_type)
 
-        # Anything left in the bib_ref_items goes at the end
-        for key, value in bib_ref_dict.items():
+        # Anything left in the bib_ref_dict_keys goes at the end
+        for key in bib_ref_dict_keys:
+            value = bib_ref_dict[key]
             caption = key.capitalize()
             for entry in value:
                 text_elements.append(f"{caption} {entry}")

--- a/scripts/avalon.py
+++ b/scripts/avalon.py
@@ -77,7 +77,6 @@ class Object:
         # not currently supported
         self.file = []  # (file, label)
 
-        self.handle = ''
 
     def process_umdm(self, umdm_path: Path) -> None:
         """ Gather data from the UMDM xml. """
@@ -380,7 +379,6 @@ class ObjectToCsvConverter:
         self.headers = \
             ["Bibliographic ID Label", "Bibliographic ID"] \
             + ["Other Identifier Type", "Other Identifier"] * column_counts.max_other_identifier \
-            + ["Handle"] \
             + ["Title"] \
             + ["Creator"] * column_counts.max_creator \
             + ["Contributor"] * column_counts.max_contributor \
@@ -412,9 +410,6 @@ class ObjectToCsvConverter:
 
             # "Other Identifier Type", Other Identifier"
             *self.multicolumn(obj.other_identifier, 2, self.column_counts.max_other_identifier),
-
-            # "Handle"
-            obj.handle,
 
             # "Title"
             obj.title,
@@ -591,7 +586,8 @@ def main(args: Namespace) -> None:
 
                 obj.title = record['title']
                 obj.other_identifier.append(("local", umdm))
-                obj.handle = record['handle']
+                obj.other_identifier.append(('handle', record['handle']))
+
                 obj.process_umdm(target / record['location'] / 'umdm.xml')
 
                 objects.append(obj)

--- a/scripts/unit_tests.py
+++ b/scripts/unit_tests.py
@@ -4,74 +4,93 @@
 import unittest
 
 from xml.dom.minidom import parseString
-from avalon import bibref_to_note_text, collapse_whitespace_nodes
+from avalon import BibRefToTextConverter, XmlUtils
 
 
-class TestBibRefToNoteText(unittest.TestCase):
-    '''Test cases for the 'bibref_to_note_text' method in avalon.py'''
+class TestBibRefToTextConverter(unittest.TestCase):
+    '''Test cases for the 'bib_ref_to_note_text' method in avalon.py'''
 
     @staticmethod
     def to_element(xml: str):
         '''Converts the given string into minidom Element'''
         doc = parseString(str(xml))
-        collapse_whitespace_nodes(doc)
+        XmlUtils.collapse_whitespace_nodes(doc)
         doc_element = doc.documentElement
         return doc_element
 
-    def test_bibref_with_no_children(self):
+    def test_bib_ref_with_no_children(self):
         xml = '<bibRef />'
-        bibref = self.to_element(xml)
-        self.assertEqual('', bibref_to_note_text(bibref))
+        bib_ref = self.to_element(xml)
+        self.assertEqual('', BibRefToTextConverter.as_text(bib_ref))
 
         xml = '<bibRef></bibRef>'
-        bibref = self.to_element(xml)
-        self.assertEqual('', bibref_to_note_text(bibref))
+        bib_ref = self.to_element(xml)
+        self.assertEqual('', BibRefToTextConverter.as_text(bib_ref))
 
-    def test_bibref_with_only_title(self):
+    def test_bib_ref_with_only_title(self):
         xml = '<bibRef>\n        <title type="main">Madrigal Singers</title>\n      </bibRef>'
-        bibref = self.to_element(xml)
-        self.assertEqual('Madrigal Singers', bibref_to_note_text(bibref))
+        bib_ref = self.to_element(xml)
+        self.assertEqual('Madrigal Singers', BibRefToTextConverter.as_text(bib_ref))
 
-    def test_bibref_with_title_and_accession(self):
+    def test_bib_ref_with_title_and_accession(self):
         xml = '<bibRef><title type="main">University of Maryland\xa0Football\xa0Heritage\xa0Film\xa0Collection</title>\n<bibScope type="accession">2011-166</bibScope></bibRef>'
-        bibref = self.to_element(xml)
-        self.assertEqual('University of Maryland\xa0Football\xa0Heritage\xa0Film\xa0Collection, Accession 2011-166', bibref_to_note_text(bibref))
+        bib_ref = self.to_element(xml)
+        self.assertEqual('University of Maryland\xa0Football\xa0Heritage\xa0Film\xa0Collection, Accession 2011-166', BibRefToTextConverter.as_text(bib_ref))
 
-    def test_bibref_with_title_and_box_and_accession(self):
+    def test_bib_ref_with_title_and_box_and_accession(self):
         xml = '<bibRef>\n        <title type="main">WMUC Archives</title>\n        <bibScope type="box">1</bibScope>\n        <bibScope type="accession">2011-084</bibScope>\n      </bibRef>'
-        bibref = self.to_element(xml)
-        self.assertEqual('WMUC Archives, Box 1, Accession 2011-084', bibref_to_note_text(bibref))
+        bib_ref = self.to_element(xml)
+        self.assertEqual('WMUC Archives, Accession 2011-084, Box 1', BibRefToTextConverter.as_text(bib_ref))
 
-    def test_bibref_with_empty_title_and_empty_box_and_accession(self):
+    def test_bib_ref_with_empty_title_and_empty_box_and_accession(self):
         xml = '<bibRef>\n                <title type="main"/>\n                <bibScope type="box"/>\n                <bibScope type="accession">2011-084</bibScope>\n              </bibRef>'
-        bibref = self.to_element(xml)
-        self.assertEqual('Accession 2011-084', bibref_to_note_text(bibref))
+        bib_ref = self.to_element(xml)
+        self.assertEqual('Accession 2011-084', BibRefToTextConverter.as_text(bib_ref))
 
-    def test_bibref_with_title_and_series_and_box_and_folder_and_item(self):
+    def test_bib_ref_with_title_and_series_and_box_and_folder_and_item(self):
         xml = '<bibRef>\n        <title type="main">Jackson R. Bryer Interviews Collection</title>\n        <bibScope type="series">1</bibScope>\n        <bibScope type="box">1</bibScope>\n        <bibScope type="folder">1</bibScope>\n        <bibScope type="item">5.0</bibScope>\n      </bibRef>'
-        bibref = self.to_element(xml)
-        self.assertEqual('Jackson R. Bryer Interviews Collection, Series 1, Box 1, Folder 1, Item 5.0', bibref_to_note_text(bibref))
+        bib_ref = self.to_element(xml)
+        self.assertEqual('Jackson R. Bryer Interviews Collection, Series 1, Box 1, Folder 1, Item 5.0', BibRefToTextConverter.as_text(bib_ref))
 
-    def test_bibref_with_no_title_and_accession(self):
+    def test_bib_ref_with_no_title_and_accession(self):
         xml = '<bibRef>\n                \n                \n                <bibScope type="accession">2011-084</bibScope>\n              </bibRef>'
-        bibref = self.to_element(xml)
-        self.assertEqual('Accession 2011-084', bibref_to_note_text(bibref))
+        bib_ref = self.to_element(xml)
+        self.assertEqual('Accession 2011-084', BibRefToTextConverter.as_text(bib_ref))
 
-    def test_bibref_with_empty_title(self):
+    def test_bib_ref_with_empty_title(self):
         xml = '<bibRef><title type="main"/></bibRef>'
-        bibref = self.to_element(xml)
-        self.assertEqual('', bibref_to_note_text(bibref))
+        bib_ref = self.to_element(xml)
+        self.assertEqual('', BibRefToTextConverter.as_text(bib_ref))
 
     def test_bib_with_title_and_series_and_accession_and_subseries_and_item(self):
         xml = '<bibRef><title type="main">United Brotherhood of Carpenters and Joiners America (UBC) archives</title>\n<bibScope type="series">16</bibScope>\n<bibScope type="accession">1995-94</bibScope>\n<bibScope type="subseries">2</bibScope>\n<bibScope type="item">Audio #32</bibScope></bibRef>'
-        bibref = self.to_element(xml)
-        self.assertEqual('United Brotherhood of Carpenters and Joiners America (UBC) archives, Series 16, Accession 1995-94, Subseries 2, Item Audio #32', bibref_to_note_text(bibref))
+        bib_ref = self.to_element(xml)
+        self.assertEqual('United Brotherhood of Carpenters and Joiners America (UBC) archives, Accession 1995-94, Series 16, Subseries 2, Item Audio #32', BibRefToTextConverter.as_text(bib_ref))
 
-    def test_bibref_with_title_and_accession_displays_title_first(self):
+    def test_bib_ref_with_title_and_accession_displays_title_first(self):
         xml = '<bibRef><bibScope type="accession">2011-166</bibScope>\n<title type="main">Test Title</title></bibRef>'
-        bibref = self.to_element(xml)
-        self.assertEqual('Test Title, Accession 2011-166', bibref_to_note_text(bibref))
+        bib_ref = self.to_element(xml)
+        self.assertEqual('Test Title, Accession 2011-166', BibRefToTextConverter.as_text(bib_ref))
 
+    def test_bib_ref_with_unexpected_bibscope_puts_bibscope_at_end(self):
+        xml = '<bibRef><title type="main">Test Title</title>\n<bibScope type="accession">2011-166</bibScope><bibScope type="unknownScope">abc123</bibScope>\n</bibRef>'
+        bib_ref = self.to_element(xml)
+        self.assertEqual('Test Title, Accession 2011-166, Unknownscope abc123', BibRefToTextConverter.as_text(bib_ref))
+
+    def test_bib_ref_with_unexpected_xml_puts_xml_at_end(self):
+        xml = '<bibRef><title type="main">Test Title</title>\n<subtitle>Test Subtitle</subtitle>\n<bibScope type="accession">2011-166</bibScope><bibScope type="unknownScope">abc123</bibScope>\n</bibRef>'
+        bib_ref = self.to_element(xml)
+        self.assertEqual('Test Title, Accession 2011-166, Subtitle Test Subtitle, Unknownscope abc123', BibRefToTextConverter.as_text(bib_ref))
+
+    def test_bib_ref_with_multiple_titles_displays_multiple_titles(self):
+        xml = '<bibRef><title type="main">Test Title 1</title>\n<title type="main">Test Title 2</title>\n<bibScope type="accession">2011-166</bibScope>\n</bibRef>'
+        bib_ref = self.to_element(xml)
+        self.assertEqual('Test Title 1, Test Title 2, Accession 2011-166', BibRefToTextConverter.as_text(bib_ref))
+
+    def test_bib_ref_with_multiple_bibscopes_displays_multiple_entries(self):
+        xml = '<bibRef><title type="main">Test Title</title>\n<bibScope type="accession">2011-166</bibScope><bibScope type="accession">ABC-123</bibScope></bibRef>'
+        bib_ref = self.to_element(xml)
+        self.assertEqual('Test Title, Accession 2011-166, Accession ABC-123', BibRefToTextConverter.as_text(bib_ref))
 
 if __name__ == '__main__':
     unittest.main()

--- a/scripts/unit_tests.py
+++ b/scripts/unit_tests.py
@@ -33,7 +33,6 @@ class TestObjectToCsvConverter(unittest.TestCase):
         self.column_counts = CsvColumnCounts([self.obj])
         self.converter = ObjectToCsvConverter(self.column_counts)
 
-
     def test_headers(self):
         expected_headers = \
             ['Bibliographic ID Label', 'Bibliographic ID'] \

--- a/scripts/unit_tests.py
+++ b/scripts/unit_tests.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+
+'''Unit tests for Python scripts'''
+import unittest
+
+from xml.dom.minidom import parseString
+from avalon import bibref_to_note_text, collapse_whitespace_nodes
+
+
+class TestBibRefToNoteText(unittest.TestCase):
+    '''Test cases for the 'bibref_to_note_text' method in avalon.py'''
+
+    @staticmethod
+    def to_element(xml: str):
+        '''Converts the given string into minidom Element'''
+        doc = parseString(str(xml))
+        collapse_whitespace_nodes(doc)
+        doc_element = doc.documentElement
+        return doc_element
+
+    def test_bibref_with_no_children(self):
+        xml = '<bibRef />'
+        bibref = self.to_element(xml)
+        self.assertEqual('', bibref_to_note_text(bibref))
+
+        xml = '<bibRef></bibRef>'
+        bibref = self.to_element(xml)
+        self.assertEqual('', bibref_to_note_text(bibref))
+
+    def test_bibref_with_only_title(self):
+        xml = '<bibRef>\n        <title type="main">Madrigal Singers</title>\n      </bibRef>'
+        bibref = self.to_element(xml)
+        self.assertEqual('Madrigal Singers', bibref_to_note_text(bibref))
+
+    def test_bibref_with_title_and_accession(self):
+        xml = '<bibRef><title type="main">University of Maryland\xa0Football\xa0Heritage\xa0Film\xa0Collection</title>\n<bibScope type="accession">2011-166</bibScope></bibRef>'
+        bibref = self.to_element(xml)
+        self.assertEqual('University of Maryland\xa0Football\xa0Heritage\xa0Film\xa0Collection, Accession 2011-166', bibref_to_note_text(bibref))
+
+    def test_bibref_with_title_and_box_and_accession(self):
+        xml = '<bibRef>\n        <title type="main">WMUC Archives</title>\n        <bibScope type="box">1</bibScope>\n        <bibScope type="accession">2011-084</bibScope>\n      </bibRef>'
+        bibref = self.to_element(xml)
+        self.assertEqual('WMUC Archives, Box 1, Accession 2011-084', bibref_to_note_text(bibref))
+
+    def test_bibref_with_empty_title_and_empty_box_and_accession(self):
+        xml = '<bibRef>\n                <title type="main"/>\n                <bibScope type="box"/>\n                <bibScope type="accession">2011-084</bibScope>\n              </bibRef>'
+        bibref = self.to_element(xml)
+        self.assertEqual('Accession 2011-084', bibref_to_note_text(bibref))
+
+    def test_bibref_with_title_and_series_and_box_and_folder_and_item(self):
+        xml = '<bibRef>\n        <title type="main">Jackson R. Bryer Interviews Collection</title>\n        <bibScope type="series">1</bibScope>\n        <bibScope type="box">1</bibScope>\n        <bibScope type="folder">1</bibScope>\n        <bibScope type="item">5.0</bibScope>\n      </bibRef>'
+        bibref = self.to_element(xml)
+        self.assertEqual('Jackson R. Bryer Interviews Collection, Series 1, Box 1, Folder 1, Item 5.0', bibref_to_note_text(bibref))
+
+    def test_bibref_with_no_title_and_accession(self):
+        xml = '<bibRef>\n                \n                \n                <bibScope type="accession">2011-084</bibScope>\n              </bibRef>'
+        bibref = self.to_element(xml)
+        self.assertEqual('Accession 2011-084', bibref_to_note_text(bibref))
+
+    def test_bibref_with_empty_title(self):
+        xml = '<bibRef><title type="main"/></bibRef>'
+        bibref = self.to_element(xml)
+        self.assertEqual('', bibref_to_note_text(bibref))
+
+    def test_bib_with_title_and_series_and_accession_and_subseries_and_item(self):
+        xml = '<bibRef><title type="main">United Brotherhood of Carpenters and Joiners America (UBC) archives</title>\n<bibScope type="series">16</bibScope>\n<bibScope type="accession">1995-94</bibScope>\n<bibScope type="subseries">2</bibScope>\n<bibScope type="item">Audio #32</bibScope></bibRef>'
+        bibref = self.to_element(xml)
+        self.assertEqual('United Brotherhood of Carpenters and Joiners America (UBC) archives, Series 16, Accession 1995-94, Subseries 2, Item Audio #32', bibref_to_note_text(bibref))
+
+    def test_bibref_with_title_and_accession_displays_title_first(self):
+        xml = '<bibRef><bibScope type="accession">2011-166</bibScope>\n<title type="main">Test Title</title></bibRef>'
+        bibref = self.to_element(xml)
+        self.assertEqual('Test Title, Accession 2011-166', bibref_to_note_text(bibref))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/test/resources/scripts/avalon/umd_55387_umdm.xml
+++ b/src/test/resources/scripts/avalon/umd_55387_umdm.xml
@@ -1,0 +1,61 @@
+<descMeta xml:lang="en">
+  <mediaType type="movingImage">
+    <form type="analog">documentary</form>
+  </mediaType>
+  <title type="main">The Gordon W. Prange Collection: saving hidden history, Japan 1945-1949</title>
+  <agent type="creator">
+    <corpName>University Video, University of Maryland, College Park</corpName>
+  </agent>
+  <agent type="creator">
+    <persName>Vikor, Desider L., 1950-</persName>
+  </agent>
+  <agent type="creator">
+    <persName>Prange, Winfred</persName>
+  </agent>
+  <agent type="creator">
+    <persName>Prange, Polly</persName>
+  </agent>
+  <agent type="provider">
+    <corpName>University of Maryland</corpName>
+  </agent>
+  <covPlace>
+    <geogName type="continent">North America</geogName>
+    <geogName type="country">United States of America</geogName>
+    <geogName type="region">Maryland</geogName>
+    <geogName type="settlement">College Park</geogName>
+  </covPlace>
+  <covTime>
+    <century era="ad">2001-2100</century>
+    <date era="ad" type="exact">2008</date>
+  </covTime>
+  <culture>American</culture>
+  <culture>Japanese</culture>
+  <language>en</language>
+  <description type="summary">Introduction of the Gordon W. Prange Collection, University of
+        Maryland Libraries. </description>
+  <subject type="browse">Government, Law, Politics</subject>
+  <subject type="browse">University of Maryland</subject>
+  <subject scheme="LCNAF" type="topical">Prange, Gordon W. (Gordon William), 1910-1980</subject>
+  <subject scheme="LCSH" type="topical">Gordon W. Prange Collection (University of Maryland at
+        College Park. Libraries)</subject>
+  <subject scheme="LCSH" type="topical">Japan -- History -- Allied occupation, 1945-1952 --
+        Library resources</subject>
+  <subject scheme="LCSH" type="topical">Japan -- History -- Allied occupation, 1945-1952 --
+        Censorship</subject>
+  <subject scheme="LCSH" type="topical">Supreme Commander for the Allied Powers. Civil Censorship
+        Detachment</subject>
+  <subject type="temporal">
+    <century>1901-2000</century>
+  </subject>
+  <physDesc>
+    <extent units="minutes">10</extent>
+    <color>color</color>
+  </physDesc>
+  <relationships></relationships>
+  <repository>
+    <corpName>Gordon W. Prange Collection</corpName>
+  </repository>
+  <rights type="copyrightowner">University of Maryland</rights>
+  <rights> This video or portions therein cannot be reproduced without the written permission of
+        the Gordon Prange Collection. Contact prangebunko@umd.edu for more information. </rights>
+</descMeta>


### PR DESCRIPTION
Refactored code to make it more testable. This included:

* Added "CsvColumnCounts" class to calculate and manage the "multicolumn" field counts in the CSV output.
* Added "ObjectToCsvConverter" class to manage the CSV output. This places the "headers" generation, and the CSV output into the same class, which seemed advantageous, since they would need to be modified together if there are changes. Also moved the "multicolumn" function into this class as it is used for the CSV output.
*  Modified the "write_csv" function to used the refactored classes.
* Wrote some unit tests to verify the behavior of the new classes.

Replaced the explicit "Handle" field in the CSV output with an additional "Other Identifier" field, with an "Other Identifier Type" of "handle" and updated the unit tests.

https://issues.umd.edu/browse/LIBAVALON-172