### PR TITLE
LIBHYDRA-586. Fixed "creator/contributor" parsing in "archelon.py"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ pycodestyle==2.10.0
 pyparsing==3.0.9
 pytest==7.2.1
 python-dateutil==2.8.2
-PyYAML==6.0
+PyYAML==6.0.1
 requests==2.28.2
 six==1.16.0
 tomli==2.0.1

--- a/scripts/archelon.py
+++ b/scripts/archelon.py
@@ -143,16 +143,16 @@ class Object:
 
                     elif (agent_type == 'creator' and
                           (
-                            child.nodeName == 'corpName' and (agent_role is None or agent_role == 'author')
-                            or child.nodeName == 'persName' and (agent_role is None or agent_role == 'author')
+                            child.nodeName == 'corpName' and ((not agent_role) or agent_role == 'author')
+                            or child.nodeName == 'persName' and ((not agent_role) or agent_role == 'author')
                             or child.nodeName == 'other'
                           )):
                         self.creator.append(text)
 
                     elif (agent_type == 'contributor' and
                           (
-                            child.nodeName == 'corpName' and (agent_role is None or agent_role in ('illustrator', 'editor'))
-                            or child.nodeName == 'persName' and (agent_role is None or agent_role in ('illustrator', 'editor'))
+                            child.nodeName == 'corpName' and ((not agent_role) or agent_role in ('illustrator', 'editor'))
+                            or child.nodeName == 'persName' and ((not agent_role) or agent_role in ('illustrator', 'editor'))
                             or child.nodeName == 'other'
                           )):
                         self.contributor.append(text)


### PR DESCRIPTION
Modified the "creator" and "contributor" parsing in the “process_umdm” method of “scripts/archelon.py” to accept both `None` and the empty string ("") for determining "agent_role" field is empty. Prior to this change the "agent_role" was considered empty only if it was `None`.

Bumped the patch version of the "PyYAML" requirement from "6.0" to "6.0.1", so the dependency could be used (otherwise was attempting to use Cython 3.0, which is incompatible).

https://umd-dit.atlassian.net/browse/LIBHYDRA-586
